### PR TITLE
Update graphql dependency version to 16

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "arrowParens": "avoid",
   "parser": "typescript"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-type-object-id",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "A graphql scalar type for MongoDB ObjectId.",
   "main": "./dist",
   "types": "./dist",
@@ -34,19 +34,19 @@
     "@graphql-tools/schema": "^8.1.0",
     "@types/node": "^16.6.1",
     "@types/tap": "^15.0.5",
-    "@typescript-eslint/eslint-plugin": "^4.29.1",
-    "@typescript-eslint/parser": "^4.29.1",
+    "@typescript-eslint/eslint-plugin": "^5.39.0",
+    "@typescript-eslint/parser": "^5.39.0",
     "chokidar-cli": "^3.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
     "fox1t-tsconfig": "^0.2.0",
-    "graphql": "^15.5.1",
+    "graphql": "^16.6.0",
     "graphql-tag": "^2.12.5",
     "graphql-tools": "^8.1.0",
     "husky": "^7.0.1",
     "mongodb": "^4.1.0",
-    "prettier": "^2.3.2",
+    "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "tap": "^15.0.9",
     "tap-mocha-reporter": "^5.0.1",
@@ -63,7 +63,7 @@
     }
   },
   "peerDependencies": {
-    "graphql": "15.x",
+    "graphql": "16.x",
     "mongodb": "4.x"
   },
   "directories": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const GraphQLObjectId = new GraphQLScalarType({
     if (ast.kind === Kind.STRING) {
       return parseValue(ast.value)
     }
-    throw new GraphQLError(`Provided value "${print(ast)}" is not a valid ObjectId`, ast)
+    throw new GraphQLError(`Provided value "${print(ast)}" is not a valid ObjectId`, { nodes: ast })
   },
 })
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,26 +1,26 @@
 import { ObjectId } from 'mongodb'
 import { GraphQLError } from 'graphql'
 
-export function isValidStringObjectId(value: string): boolean {
+export function isValidStringObjectId(value: unknown): boolean {
   return (
     typeof value === 'string' && ObjectId.isValid(value) && new ObjectId(value).toString() === value
   )
 }
 
-export function isValidObjectId(value: ObjectId): boolean {
+export function isValidObjectId(value: any): boolean {
   return ObjectId.isValid(value) && new ObjectId(value).toString() === value.toString()
 }
 
-export function parseValue(value: string): ObjectId {
+export function parseValue(value: unknown): ObjectId {
   if (!isValidStringObjectId(value)) {
     throw new GraphQLError(`Provided value "${value}" is not a valid ObjectId`)
   }
-  return new ObjectId(value)
+  return new ObjectId(value as string)
 }
 
-export function serialize(value: ObjectId): string {
+export function serialize(value: unknown): string {
   if (!isValidObjectId(value)) {
     throw new GraphQLError(`Provided value "${value}" is not a valid ObjectId`)
   }
-  return value.toString()
+  return (value as ObjectId).toString()
 }

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -61,7 +61,7 @@ test('parseValue: should throw and error with invalid ObjectId', t => {
   try {
     parseValue('invalid')
   } catch (err) {
-    t.same(err.message, `Provided value "invalid" is not a valid ObjectId`)
+    t.same((err as Error).message, `Provided value "invalid" is not a valid ObjectId`)
   }
 })
 test('parseValue: should return an ObjectId', t => {
@@ -78,7 +78,7 @@ test('serialize: should throw and error with invalid ObjectId', t => {
   try {
     serialize('invalid' as unknown as ObjectId)
   } catch (err) {
-    t.same(err.message, `Provided value "invalid" is not a valid ObjectId`)
+    t.same((err as Error).message, `Provided value "invalid" is not a valid ObjectId`)
   }
 })
 test('serialize: should return an ObjectId', t => {


### PR DESCRIPTION
- Updated graphql dependency to 16
- Updated `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser` and `prettier` to avoid warning message
`WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.`
-Updated package version to 0.0.6

**N.B:** I added a type `any` in the `isValidObjectId` [method](https://github.com/alemagio/graphql-type-object-id/blob/7fdec1b840e49a92345e86bf98445629cac342ed/src/util.ts#L10) because I didn't find a better way to cast unknown, let me know if you find a better solution